### PR TITLE
add:新規ユーザー登録画面作成 #11

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def new
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>medical record</title>
+</head>
+<body>
+  <header class="site-header">
+    <h1>medical record</h1>
+    <nav class="nav-menu">
+    <!-- リンク未反映：各リンク先作成後に修正 -->
+      <%= link_to "記録", "#", class: "nav-button" %>
+      <%= link_to "サマリー", "#", class: "nav-button" %>
+      <%= link_to "一覧", "#", class: "nav-button" %>
+    </nav>
+  </header>
+
+  <main class="login-main">
+    <form class="login-form">
+      <div class="form-group">
+        <label for="name">名前</label>
+        <input type="text id="name" name="name">
+      </div>
+
+      <div class="form-group">
+        <label for="email">メールアドレス</label>
+        <input type="email" id="email" name="email">
+      </div>
+
+      <div class="form-group">
+        <label for="password">パスワード</label>
+        <input type="password" id="password" name="password">
+      </div>
+      <!-- リンク未反映：各リンク先作成後に修正 -->
+      <%= link_to "新規登録", "#", class: "register-button" %>
+    </form>
+  </main>
+</body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "signup", to: "users#new"
   root 'pages#home'
   get "pages/home"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get users_new_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
issue #11 
新規ユーザー登録画面：https://medical-record-xqit.onrender.com/signup

## 実装内容
新規ユーザー登録画面を作成
- ログインページを流用（ログインボタンのみ削除）

## 今後の予定
ログイン画面の改修時に同じようにデザイン改善