### PR TITLE
add:新規ユーザー登録のバリデーション追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :name, presence: true, length: { maximum: 50 }
+
+  validates :password, presence: true, length: { minimum: 6 }, if: :password_required?
+
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,9 @@
   </header>
 
   <main class="login-main">
-    <%= form_for(resource, as: resource, url: registration_path(resource_name), html: { class: "login-form" }) do |f| %>
+    <%= render "shared/error_messages", object: resource %>
+
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "login-form" }) do |f| %>
 
       <!-- 名前  -->
       <div class="form-group">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,6 +17,8 @@
   </header>
 
   <main class="login-main">
+    <%= render "shared/error_messages", object: resource %>
+
     <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "login-form" }) do |f| %>
       
       <!-- メールアドレス -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,16 +7,14 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application", media: "all" %>
-
-    <%= yield :head %>
+    <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload", media: "all" %>
 
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= yield :head %>
   </head>
 
   <body>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="error-messages">
+    <ul>
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>


### PR DESCRIPTION
issue #13 

## 実装内容
- 名前/password/emailに対するバリデーションをapp/models/user.rbに追加し、エラーメッセージの表示を実装。
- エラーメッセージはapp/views/shared/_error_messages.html.erbで管理。

## 今後の予定
子ども新規登録時、発熱やメモ等の症状記録時に対するバリデーションを追加。