### PR TITLE
add:記録スタート機能

### DIFF
--- a/app/controllers/disease_records_controller.rb
+++ b/app/controllers/disease_records_controller.rb
@@ -1,0 +1,26 @@
+class DiseaseRecordsController < ApplicationController
+  before_action :set_kid
+
+  def new
+    @disease_record = @kid.disease_records.new
+  end
+
+  def create
+    @disease_record = @kid.disease_records.build(disease_record_params)
+    if @disease_record.save
+        redirect_to kid_path(@kid), notice: "記録スタート"
+    else
+        render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_kid
+    @kid = current_user.kids.find(params[:kid_id])
+  end
+
+  def disease_record_params
+    params.require(:disease_record).permit(:start_at, :end_at, :notes)
+  end
+end

--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -19,8 +19,8 @@ class KidsController < ApplicationController
   end
 
   def select
-    @kids = current_user.kids.find(params[:id])
-    redirect_to kid_records_path(@kid)
+    @kid = current_user.kids.find(params[:id])
+    redirect_to new_kid_reported_symptom_path(@kid)
   end
 
   private

--- a/app/controllers/reported_symptoms_controller.rb
+++ b/app/controllers/reported_symptoms_controller.rb
@@ -1,0 +1,2 @@
+class ReportedSymptomsController < ApplicationController
+end

--- a/app/controllers/symptom_names_controller.rb
+++ b/app/controllers/symptom_names_controller.rb
@@ -1,0 +1,2 @@
+class SymptomNamesController < ApplicationController
+end

--- a/app/helpers/disease_records_helper.rb
+++ b/app/helpers/disease_records_helper.rb
@@ -1,0 +1,2 @@
+module DiseaseRecordsHelper
+end

--- a/app/helpers/reported_symptoms_helper.rb
+++ b/app/helpers/reported_symptoms_helper.rb
@@ -1,0 +1,2 @@
+module ReportedSymptomsHelper
+end

--- a/app/helpers/symptom_names_helper.rb
+++ b/app/helpers/symptom_names_helper.rb
@@ -1,0 +1,2 @@
+module SymptomNamesHelper
+end

--- a/app/models/disease_record.rb
+++ b/app/models/disease_record.rb
@@ -1,0 +1,5 @@
+class DiseaseRecord < ApplicationRecord
+  belongs_to :kid
+  has_many :reported_symptoms, dependent: :destroy
+  validates :start_at, presence: true
+end

--- a/app/models/kid.rb
+++ b/app/models/kid.rb
@@ -4,4 +4,6 @@ class Kid < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
 
   validates :birthday, presence: true
+
+  has_many :disease_records, dependent: :destroy
 end

--- a/app/models/reported_symptom.rb
+++ b/app/models/reported_symptom.rb
@@ -1,0 +1,4 @@
+class ReportedSymptom < ApplicationRecord
+  belongs_to :disease_record
+  belongs_to :symptom_name
+end

--- a/app/models/symptom_name.rb
+++ b/app/models/symptom_name.rb
@@ -1,0 +1,2 @@
+class SymptomName < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
     member do
       get :select
     end
+    resources :disease_records, only: [:new, :create]
+    resources :reported_symptoms, only: [:new, :create]
   end
   
   # get "signup", to: "users#new"

--- a/db/migrate/20251106052449_create_disease_records.rb
+++ b/db/migrate/20251106052449_create_disease_records.rb
@@ -1,0 +1,12 @@
+class CreateDiseaseRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :disease_records do |t|
+      t.references :kid, null: false, foreign_key: true
+      t.datetime :start_at
+      t.datetime :end_at
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251106061556_create_symptom_names.rb
+++ b/db/migrate/20251106061556_create_symptom_names.rb
@@ -1,0 +1,9 @@
+class CreateSymptomNames < ActiveRecord::Migration[7.2]
+  def change
+    create_table :symptom_names do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_04_061131) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_06_061556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "disease_records", force: :cascade do |t|
+    t.bigint "kid_id", null: false
+    t.datetime "start_at"
+    t.datetime "end_at"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["kid_id"], name: "index_disease_records_on_kid_id"
+  end
 
   create_table "kids", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -21,6 +31,12 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_04_061131) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_kids_on_user_id"
+  end
+
+  create_table "symptom_names", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,5 +52,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_04_061131) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "disease_records", "kids"
   add_foreign_key "kids", "users"
 end

--- a/test/controllers/disease_records_controller_test.rb
+++ b/test/controllers/disease_records_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiseaseRecordsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/reported_symptoms_controller_test.rb
+++ b/test/controllers/reported_symptoms_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReportedSymptomsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/symptom_names_controller_test.rb
+++ b/test/controllers/symptom_names_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SymptomNamesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/disease_records.yml
+++ b/test/fixtures/disease_records.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  kid: one
+  start_at: 2025-11-06 14:24:49
+  end_at: 2025-11-06 14:24:49
+  name: MyString
+
+two:
+  kid: two
+  start_at: 2025-11-06 14:24:49
+  end_at: 2025-11-06 14:24:49
+  name: MyString

--- a/test/fixtures/reported_symptoms.yml
+++ b/test/fixtures/reported_symptoms.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  disease_record: one
+  symptom_name: one
+  recorded_at: 2025-11-06 15:10:22
+  memo: MyText
+  body_temperature: 1.5
+
+two:
+  disease_record: two
+  symptom_name: two
+  recorded_at: 2025-11-06 15:10:22
+  memo: MyText
+  body_temperature: 1.5

--- a/test/fixtures/symptom_names.yml
+++ b/test/fixtures/symptom_names.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/disease_record_test.rb
+++ b/test/models/disease_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiseaseRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/reported_symptom_test.rb
+++ b/test/models/reported_symptom_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReportedSymptomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/symptom_name_test.rb
+++ b/test/models/symptom_name_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SymptomNameTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
issue #21 

## 実装内容
- DiseaseRecords/ReportedSymptoms/SymptomNamesのモデル/コントローラー作成（DiseaseRecordsのみ機能実装のためコード編集済み。残り二つは今後の実装で編集予定。）
- 子選択後に記録画面に遷移するよう編集

## 今後の予定
- viewは症状記録画面にポップアップでスタートボタンを表示させるよう変更（使いやすさのため）。