### PR TITLE
add:症状記録機能

### DIFF
--- a/app/controllers/disease_records_controller.rb
+++ b/app/controllers/disease_records_controller.rb
@@ -1,5 +1,6 @@
 class DiseaseRecordsController < ApplicationController
   before_action :set_kid
+  before_action :set_disease_record, only: [:end_form, :end_update]
 
   def new
     @disease_record = @kid.disease_records.new
@@ -14,10 +15,27 @@ class DiseaseRecordsController < ApplicationController
     end
   end
 
+  def end_form
+  end
+
+  def end_update
+    if @disease_record.update(end_at: disease_record_params[:end_at])
+      redirect_to kid_path(@kid), notice: "体調不良の終了日時を登録しました。"
+    else
+      flash.now[:alert] = "終了日時の登録に失敗しました。"
+      render :end_form, status: :unprocessable_entity
+    end
+  end
+
+
   private
 
   def set_kid
     @kid = current_user.kids.find(params[:kid_id])
+  end
+
+  def set_disease_record
+    @disease_record = @kid.disease_records.find(params[:id])
   end
 
   def disease_record_params

--- a/app/controllers/reported_symptoms_controller.rb
+++ b/app/controllers/reported_symptoms_controller.rb
@@ -1,2 +1,42 @@
 class ReportedSymptomsController < ApplicationController
+  before_action :set_kid
+  before_action :set_disease_record
+
+  def new
+    if @disease_record.nil?
+      @show_start_popup = true
+      @disease_record = @kid.disease_records.new
+    else
+      @reported_symptom = @disease_record.reported_symptoms.new
+    end
+  end
+
+  def create
+    @reported_symptom = @disease_record.reported_symptoms.new(reported_symptom_params)
+
+    if @reported_symptom.save
+      if params[:commit] == "治った！"
+        @disease_record.update(end_at: Time.current)
+        redirect_to kid_path(@kid), notice: "看病お疲れ様でした！"
+      else
+        redirect_to new_kid_reported_symptom_path(@kid), notice: "記録しました"
+      end
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_kid
+    @kid = current_user.kids.find(params[:kid_id])
+  end
+
+  def set_disease_record
+    @disease_record = @kid.disease_records.find_by(end_at: nil)
+  end
+
+  def reported_symptom_params
+    params.require(:reported_symptom).permit(:symptom_name_id, :recorded_at, :memo, :body_temperature, :name)
+  end
 end

--- a/app/views/reported_symptoms/new.html.erb
+++ b/app/views/reported_symptoms/new.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>medical record - お子さま登録</title>
+</head>
+<body>
+  <header class="site-header">
+    <h1>medical record</h1>
+    <nav class="nav-menu">
+      <!-- リンク未反映：各リンク先作成後に修正 -->
+      <%= link_to "記録", "#", class: "nav-button" %>
+      <%= link_to "サマリー", "#", class: "nav-button" %>
+      <%= link_to "一覧", "#", class: "nav-button" %>
+
+      <% if user_signed_in? %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
+      <% end %>
+    </nav>
+  </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,14 @@ Rails.application.routes.draw do
     member do
       get :select
     end
-    resources :disease_records, only: [:new, :create]
+
+    resources :disease_records, only: [:new, :create] do
+      member do
+        get :end_form
+        patch :end_update
+      end
+    end
+
     resources :reported_symptoms, only: [:new, :create]
   end
   

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,18 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+symptom_names = [
+  "頭痛",
+  "咳",
+  "鼻水",
+  "発疹",
+  "嘔吐",
+  "便"
+]
+
+symptom_names.each do |name|
+  SymptomName.find_or_create_by!(name: name)
+end
+
+puts "症状名データを登録しました（#{SymptomName.count}件）"
+


### PR DESCRIPTION
issue #23 

## 実装内容
- 終了日時のない disease_record があるなら症状記録画面へ、なければ 「記録スタート」ポップアップを出して新しい disease_record を作成する設計
- 症状記録の初期データを作成
- 「治った！」ボタンで現在の disease_record の end_atを登録

## 今後の予定
- view作成時に動作確認
→反省点：細かな動作確認が多い場合、viewを先に作り都度動作確認を目視でできる方が効率がよかった。