### PR TITLE
fix:症状名の追記(本番DBエラー)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,7 @@ symptom_names = [
   "発疹",
   "嘔吐",
   "便"
+  "その他"
 ]
 
 symptom_names.each do |name|
@@ -22,3 +23,5 @@ end
 
 puts "症状名データを登録しました（#{SymptomName.count}件）"
 
+puts "登録済みの症状名一覧："
+SymptomName.pluck(:name).each { |n| puts " - #{n}" }


### PR DESCRIPTION
## 修正点
本番環境でのみ症状記録画面に遷移できないエラー発生。
エラーメッセージ（Render ログ)：undefined method `id' for nil:NilClass
