### PR TITLE
add:サマリー（全期間）表示機能

### DIFF
--- a/app/controllers/reported_symptoms_controller.rb
+++ b/app/controllers/reported_symptoms_controller.rb
@@ -65,6 +65,23 @@ class ReportedSymptomsController < ApplicationController
     end
   end
   
+  def summary
+    @kid = Kid.find(params[:kid_id])
+
+    @disease_record = @kid.disease_records.order(start_at: :desc).first
+
+    if @disease_record.nil?
+      redirect_to kid_path(@kid), alert: "記録中の病気がありません。"
+      return
+    end
+
+    @reported_symptoms = @disease_record.reported_symptoms.includes(:symptom_name)
+
+    @symptoms_by_date = @reported_symptoms.group_by { |rs| rs.created_at.to_date }
+
+    @symptoms_by_date = @symptoms_by_date.sort.to_h
+  end
+
   private
 
   def set_kid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     resources :reported_symptoms, only: [:new, :create] do
       collection do
         post :start_record
+        get :summary
       end
     end
   end


### PR DESCRIPTION
issue #28

## 実装内容
- start_atの日付からend_at（まだend_atがない場合は今の日付）まで、一日ごとに記録された症状一覧を抽出
- 同じ症状が複数回登録されている場合、登録されている回数分全て表示

## 今後の予定
- ヘッダーの「サマリー」ボタンから遷移（issue #44)
- 当日分のみのサマリーと体調不良開始以降全期間のサマリーと2種類のサマリー表示に改善（今回は全期間のみ）
- 同じ症状が複数回登録されている場合はカウントした回数を数値で表示
- 嘔吐等の回数や体温の推移などをグラフ化