### PR TITLE
add:サマリー(全期間)表示画面作成

### DIFF
--- a/app/controllers/reported_symptoms_controller.rb
+++ b/app/controllers/reported_symptoms_controller.rb
@@ -67,18 +67,15 @@ class ReportedSymptomsController < ApplicationController
   
   def summary
     @kid = Kid.find(params[:kid_id])
-
-    @disease_record = @kid.disease_records.order(start_at: :desc).first
-
+    @disease_record = @kid.disease_records.order(start_at: :desc, created_at: :desc).first
+  
     if @disease_record.nil?
       redirect_to kid_path(@kid), alert: "記録中の病気がありません。"
       return
     end
-
+  
     @reported_symptoms = @disease_record.reported_symptoms.includes(:symptom_name)
-
     @symptoms_by_date = @reported_symptoms.group_by { |rs| rs.created_at.to_date }
-
     @symptoms_by_date = @symptoms_by_date.sort.to_h
   end
 

--- a/app/views/reported_symptoms/summary.html.erb
+++ b/app/views/reported_symptoms/summary.html.erb
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>medical record - 症状記録</title>
+</head>
+<body>
+  <header class="site-header">
+    <h1>medical record</h1>
+    <nav class="nav-menu">
+      <!-- リンク未反映：各リンク先作成後に修正 -->
+      <%= link_to "記録", "#", class: "nav-button" %>
+      <%= link_to "サマリー", "#", class: "nav-button" %>
+      <%= link_to "一覧", "#", class: "nav-button" %>
+
+      <% if user_signed_in? %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
+      <% end %>
+    </nav>
+  </header>
+
+  <main class="login-main">
+  <h2>症状サマリー</h2>
+
+  <% if @symptoms_by_date.present? %>
+    <% @symptoms_by_date.each do |date, symptoms| %>
+      <div class="summary-day">
+        <h3><%= date.strftime("%-m月%-d日") %></h3>
+        <% symptom_names = symptoms.select { |s| s.symptom_name.present? }.sort_by { |s| s.symptom_name.id } %>
+        <% temperatures = symptoms.select { |s| s.body_temperature.present? } %>
+
+        <p>
+          <% symptom_names.each do |s| %>
+            <%= s.symptom_name.name %>、
+          <% end %>
+          <% temperatures.each do |t| %>
+            熱（<%= t.body_temperature %>℃）、
+          <% end %>
+        </p>
+      </div>
+    <% end %>
+  <% else %>
+  <p>症状の記録がありません。</p>
+  <% end %>
+
+  <div class="footer">
+    <p>
+      <%= @kid.name %>
+    </p>
+  </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
issue #27 

## 実装内容
- start_atの日付からend_at（まだend_atがない場合は今の日付）まで、一日ごとに記録された症状一覧を抽出
- 同じ症状が複数回登録されている場合、登録されている回数分全て表示

## 今後の予定
- 当日分のみのサマリーを追加（タブ選択できる形）
- 同じ症状が複数回登録されている場合はカウントした回数を数値で表示
- 嘔吐等の回数や体温の推移などをグラフ表示