### PR TITLE
add:ヘッダーから各ページへ遷移

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -6,16 +6,6 @@
   <title>medical record - ログイン</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-    </nav>
-  </header>
-
   <main class="login-main">
     <%= render "shared/error_messages", object: resource %>
 

--- a/app/views/kids/index.html.erb
+++ b/app/views/kids/index.html.erb
@@ -6,20 +6,6 @@
   <title>medical record - お子さま一覧</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-
-      <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
-      <% end %>
-    </nav>
-  </header>
-
   <main class="login-main">
     <ul>
       <% @kids.each do |kid| %>

--- a/app/views/kids/new.html.erb
+++ b/app/views/kids/new.html.erb
@@ -6,20 +6,6 @@
   <title>medical record - お子さま登録</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-
-      <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
-      <% end %>
-    </nav>
-  </header>
-
   <main class="login-main">
     <%= render "shared/error_messages", object: @kid %>
 

--- a/app/views/kids/show.html.erb
+++ b/app/views/kids/show.html.erb
@@ -6,20 +6,6 @@
   <title>medical record - 症状記録</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-
-      <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
-      <% end %>
-    </nav>
-  </header>
-
   <main class="login-main">
 
     <p>看病お疲れ様でした！！！</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,17 @@
   </head>
 
   <body>
+  <header class="site-header">
+    <h2>medical record</h2>
+    <nav class="nav-menu">
+      <% if user_signed_in? %>
+        <%= link_to "記録", new_kid_reported_symptom_path(current_user.kids.first), class: "nav-button" %>
+        <%= link_to "サマリー", summary_kid_reported_symptoms_path(current_user.kids.first), class: "nav-button" %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
+      <% end %>
+    </nav>
+  </header>
+
     <%= yield %>
   </body>
 </html>

--- a/app/views/reported_symptoms/new.html.erb
+++ b/app/views/reported_symptoms/new.html.erb
@@ -6,20 +6,6 @@
   <title>medical record - 症状記録</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-
-      <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
-      <% end %>
-    </nav>
-  </header>
-
   <main class="login-main">
     <% if flash[:notice] %>
       <p class="notice"><%= flash[:notice] %></p>

--- a/app/views/reported_symptoms/summary.html.erb
+++ b/app/views/reported_symptoms/summary.html.erb
@@ -6,20 +6,6 @@
   <title>medical record - 症状記録</title>
 </head>
 <body>
-  <header class="site-header">
-    <h1>medical record</h1>
-    <nav class="nav-menu">
-      <!-- リンク未反映：各リンク先作成後に修正 -->
-      <%= link_to "記録", "#", class: "nav-button" %>
-      <%= link_to "サマリー", "#", class: "nav-button" %>
-      <%= link_to "一覧", "#", class: "nav-button" %>
-
-      <% if user_signed_in? %>
-        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
-      <% end %>
-    </nav>
-  </header>
-
   <main class="login-main">
   <h2>症状サマリー</h2>
 


### PR DESCRIPTION
issue #44 

## 実装内容
- ヘッダーに関するコードをapp/views/layouts/application.html.erbに移動（誤って各ファイルに記載していたため）。
- 「一覧ボタン」削除（MVPリリース時には一覧機能を実装しないため）。
- 記録ボタンは症状記録画面に、サマリーボタンは全期間サマリー画面に、ログアウトボタンはログインページに遷移。

## 今後の予定
- 過去の体調不良一覧機能を実装する際、一覧ボタンを追加しヘッダーから遷移できるようにする。