### PR TITLE
fix:サマリーボタンの遷移先

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,10 @@
     <h2>medical record</h2>
     <nav class="nav-menu">
       <% if user_signed_in? %>
-        <%= link_to "記録", new_kid_reported_symptom_path(current_user.kids.first), class: "nav-button" %>
-        <%= link_to "サマリー", summary_kid_reported_symptoms_path(current_user.kids.first), class: "nav-button" %>
+        <% if @kid.present? %>
+          <%= link_to "記録", new_kid_reported_symptom_path(current_user.kids.first), class: "nav-button" %>
+          <%= link_to "サマリー", summary_kid_reported_symptoms_path(@kid), class: "nav-button" %>
+        <% end %>
         <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
       <% end %>
     </nav>


### PR DESCRIPTION
## 修正内容
どの子を選んでいても最初に登録した子のサマリーが表示されるようになっていたため、それぞれの子で表示されるよう修正。