### PR TITLE
fix:新規子ども登録画面エラー

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_current_kid
 
   protected
 
@@ -20,5 +21,23 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(resource_or_scope)
     new_user_session_path
+  end
+
+  private
+
+  def set_current_kid
+    if params[:kid_id].present?
+      @current_kid = current_user.kids.find_by(id: params[:kid_id])
+      session[:current_kid_id] = @current_kid.id if @current_kid
+    elsif session[:current_kid_id].present?
+      @current_kid = current_user.kids.find_by(id: session[:current_kid_id])
+    else
+      @current_kid = nil
+    end
+  end
+  
+  helper_method :current_kid
+  def current_kid
+    @current_kid
   end
 end

--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -20,6 +20,7 @@ class KidsController < ApplicationController
 
   def select
     @kid = current_user.kids.find(params[:id])
+    session[:current_kid_id] = @kid.id
     latest_record = @kid.disease_records.order(:start_at).last
   
     if latest_record.nil? || latest_record.end_at.present?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,9 +22,9 @@
     <h2>medical record</h2>
     <nav class="nav-menu">
       <% if user_signed_in? %>
-        <% if @kid.present? %>
-          <%= link_to "記録", new_kid_reported_symptom_path(current_user.kids.first), class: "nav-button" %>
-          <%= link_to "サマリー", summary_kid_reported_symptoms_path(@kid), class: "nav-button" %>
+        <% if current_kid.present? %>
+          <%= link_to "記録", new_kid_reported_symptom_path(current_kid), class: "nav-button" %>
+          <%= link_to "サマリー", summary_kid_reported_symptoms_path(current_kid), class: "nav-button" %>
         <% end %>
         <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-button" %>
       <% end %>


### PR DESCRIPTION
## 修正内容
ヘッダーのリンクを設定したところ、新規子ども登録画面でエラー。
子ども選択前は「記録」「サマリー」ボタンを非表示にして修正。