### PR TITLE
fix:メモと病名を一時非表示に変更

### DIFF
--- a/app/views/reported_symptoms/new.html.erb
+++ b/app/views/reported_symptoms/new.html.erb
@@ -39,15 +39,19 @@
           <%= button_tag "記録", type: "submit", name: "commit_type", value: "temperature", class: "record-button" %>
         </div>
 
+        <!-- 
+        メモ 一時非表示
         <div class="form-row">
           <%= f.text_area :memo, placeholder: "メモ", rows: 2, class: "form-control" %>
           <%= button_tag "記録", type: "submit", name: "commit_type", value: "memo", class: "record-button" %>
         </div>
 
+        病名 一時非表示
         <div class="form-row">
           <%= f.text_field :disease_name, placeholder: "病名（例: 風邪、インフルエンザなど）", class: "form-control" %>
           <%= button_tag "記録", type: "submit", name: "commit_type", value: "disease_name", class: "record-button" %>
         </div>
+        -->
       <% end %>
 
       <div class="actions">


### PR DESCRIPTION
## 修正内容
メモ：現状サマリー表示に入れていないため。今後サマリーに追加したら再表示。
病名：過去の体調不良一覧（現在未実装）で使用予定のため。一覧機能実装後に再表示。