### PR TITLE
style:全期間サマリーの表示を表に改善

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -204,3 +204,80 @@ body {
     display: flex;
     justify-content: center;
 }
+
+.symptom-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 16px;
+    justify-content: center;
+    margin-bottom: 16px;
+}
+  
+.legend-item {
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+}
+  
+.legend-color {
+    width: 12px;
+    height: 12px;
+    margin-right: 6px;
+    border-radius: 2px;
+}
+
+.legend-color.headache { background: #f44336; }
+.legend-color.cough { background: #2196f3; }
+.legend-color.runny_nose { background: #03a9f4; }
+.legend-color.rash { background: #e91e63; }
+.legend-color.vomit { background: #ff9800; }
+.legend-color.stool { background: #8bc34a; }
+.legend-color.temperature { background: #9c27b0; }
+
+.weekly-matrix {
+    display: flex;
+    gap: 48px;
+}
+  
+.week-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+  
+.day-row {
+    display: flex;
+    align-items: center;
+    margin: 0;
+}
+  
+.weekday {
+    width: 32px;
+    text-align: center;
+    font-size: 12px;
+}
+  
+.symptom-cells {
+    display: flex;
+    gap: 0;
+}
+  
+.symptom-cell {
+    width: 12px;
+    height: 24px;
+    background: #eee;
+}
+
+  /* active + 症状色 */
+.symptom-cell.active {
+    background: #4caf50;
+}
+
+.symptom-cell.headache { background: #f44336; }
+.symptom-cell.cough { background: #2196f3; }
+.symptom-cell.runny_nose { background: #03a9f4; }
+.symptom-cell.rash { background: #e91e63; }
+.symptom-cell.vomit { background: #ff9800; }
+.symptom-cell.stool { background: #8bc34a; }
+.symptom-cell.temperature { background: #9c27b0; }
+  

--- a/app/views/reported_symptoms/summary.html.erb
+++ b/app/views/reported_symptoms/summary.html.erb
@@ -60,28 +60,42 @@
     </ul>
   <% end %>
 
-
   <% if @tab == "all" %>
-    <% if @symptoms_by_date.present? %>
-      <% @symptoms_by_date.each do |date, symptoms| %>
-        <div class="summary-day">
-          <h3><%= date.strftime("%-m月%-d日") %></h3>
-          <% symptom_names = symptoms.select { |s| s.symptom_name.present? }.sort_by { |s| s.symptom_name.id } %>
-          <% temperatures = symptoms.select { |s| s.body_temperature.present? } %>
-
-          <p>
-            <% symptom_names.each do |s| %>
-              <%= s.symptom_name.name %>、
-            <% end %>
-            <% temperatures.each do |t| %>
-              熱（<%= t.body_temperature %>℃）、
-            <% end %>
-          </p>
+    <div class="symptom-legend">
+      <% @symptom_slots.each do |key, label| %>
+        <div class="legend-item">
+          <span class="legend-color <%= key %>"></span>
+          <span class="legend-label"><%= label %></span>
         </div>
       <% end %>
-    <% else %>
-      <p>症状の記録がありません。</p>
-    <% end %>
+    </div>
+
+    <div class="weekly-matrix">
+
+      <% [:last, :this].each do |week_key| %>
+        <div class="week-column">
+          <h3><%= week_key == :last ? "先週" : "今週" %></h3>
+
+          <% @weeks[week_key].each do |date| %>
+            <div class="day-row">
+              <div class="weekday">
+                <%= date.strftime("%a") %>
+              </div>
+
+              <div class="symptom-cells">
+                <% @symptom_slots.each do |key, label| %>
+                  <div class="symptom-cell <%= "active #{key}" if @matrix[date][key] %>">
+                  </div>
+                <% end %>
+              </div>
+            </div>
+
+          <% end %>
+
+        </div>
+      <% end %>
+
+    </div>
   <% end %>
 
   <div class="footer">


### PR DESCRIPTION
## 内容
- 全期間サマリーの表示形式を箇条書きから表（2週間）に変更。いつからなんの症状が出ているか経緯が分かるようにした。

## 今後の予定
- "今日" "全期間"タブの見栄えと位置を改善
- 症状の色分けのトーンを統一
- 曜日＋日付の表示