### PR TITLE
fix:Gemfile.lockを更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -368,7 +368,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  aws-sdk-s3
+  aws-sdk-s3 (~> 1.211.0)
   bootsnap
   brakeman
   capybara


### PR DESCRIPTION
## 理由
#129 のbundle installし忘れのため