### PR TITLE
fix:gemの記載箇所を変更(2回目)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,11 +56,10 @@ group :development do
 
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
-
-  gem "image_processing", "~> 1.2"
 end
 
 gem "aws-sdk-s3", '~> 1.211.0', require: false
+gem "image_processing", "~> 1.2"
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]


### PR DESCRIPTION
## 理由
image_processingをgroup内に入れてしまっていたため。
