### PR TITLE
fix:不要コード削除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,6 @@ Rails.application.configure do
   valid_levels = [:debug, :info, :warn, :error, :fatal, :unknown]
   level = (ENV.fetch("RAILS_LOG_LEVEL", "info").downcase.to_sym rescue :info)
   level = :info unless valid_levels.include?(level)
-  Rails.logger.level = level
 
   # Cache store
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
## 内容
"Rails.logger.level = level" は "config.log_level" と重複する（かつエラー原因）ため、削除。