### PR TITLE
fix:パスワード再設定画面のメッセージを日本語に修正

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -328,6 +328,7 @@ body {
     width: 100%;
     max-width: 420px;
     padding: 32px 28px;
+    margin-top: 32px;
     background: #ede8d1;
     border-radius: 16px;
     box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
@@ -337,7 +338,7 @@ body {
     min-height: 100vh;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     background: #ffffff;
 }  
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,14 @@ class User < ApplicationRecord
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
 
   has_many :kids, dependent: :destroy
+
+  validate :password_must_be_different_from_current, if: -> { password.present? && persisted? }
+
+  private
+
+  def password_must_be_different_from_current
+    if valid_password?(password)
+      errors.add(:password, :same_as_current)
+    end
+  end
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,27 @@
-<h2>Change your password</h2>
+<div class="auth-wrapper">
+  <div class="password-reset-container">
+    <h2>パスワード変更</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+        <div class="field">
+          <%= f.label :password, "新しいパスワード" %><br />
+          <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> 文字以上にしてください)</em><br />
+          <% end %>
+          <%= f.password_field :password, autofocus: true, autocomplete: "新しいパスワード" %>
+        </div>
+
+        <div class="field">
+          <%= f.label :password_confirmation, "新しいパスワード（確認用）" %><br />
+          <%= f.password_field :password_confirmation, autocomplete: "新しいパスワード" %>
+        </div>
+
+        <div class="actions">
+          <%= f.submit "パスワードを変更", class: "login-button"  %>
+        </div>
+      <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module MedicalRecordApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -69,11 +69,31 @@ ja:
     mailer:
       reset_password_instructions:
         subject: "【こどもカルテ】パスワード再設定のご案内"
+    failure:
+      invalid: "メールアドレスまたはパスワードが正しくありません"
     passwords:
       send_instructions: "パスワード再設定用のメールを送信しました。"
       updated: "パスワードが正常に変更されました。"
       updated_not_active: "パスワードが変更されました。"
-
     failure:
       invalid: "メールアドレスまたはパスワードが正しくありません。"
       unauthenticated: "ログインまたは新規登録してください。"
+  errors:
+    messages:
+      invalid: "が正しくありません"
+      template:
+        header:
+          one: "1件のエラーがあります"
+          other: "%{count}件のエラーがあります"
+      not_saved:
+        one: "1件のエラーがあります"
+        other: "%{count}件のエラーがあります"
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              invalid: "パスワード再設定用のリンクが無効です。再度お試しください。"
+            password:
+              same_as_current: "入力されたパスワードは現在設定されているものと同じです。別のパスワードを入力してください。"


### PR DESCRIPTION
## 内容
- パスワード再設定画面が日本語未対応のままになっていたため、devise.en.ymlに設定追加。
- リンクが無効/パスワードが無効の場合でメッセージを分けて表示