### PR TITLE
fix:新しいパスワードが設定できない

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,12 +12,17 @@ class User < ApplicationRecord
 
   has_many :kids, dependent: :destroy
 
-  validate :password_must_be_different_from_current, if: -> { password.present? && persisted? }
+  validate :password_must_be_different_from_current,
+           if: -> { password.present? && persisted? && will_save_change_to_encrypted_password? }
 
   private
 
   def password_must_be_different_from_current
-    if valid_password?(password)
+    previous_encrypted = encrypted_password_was
+
+    return if previous_encrypted.blank?
+
+    if Devise::Encryptor.compare(self.class, previous_encrypted, password)
       errors.add(:password, :same_as_current)
     end
   end


### PR DESCRIPTION
## 内容
エラー：過去に登録したことがないパスワードでも「現在のパスワードと同じです」となってしまう。
改善：Deviseの仕様でpassword= が呼ばれた時点でencrypted_passwordを新しいパスワードで更新している恐れがあったため、変更前のパスワードを参照するように修正。