### PR TITLE
style:全期間サマリーの表形式を変更

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,10 @@
  *= require_tree .
  *= require_self
  */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
 
 body {
     font-family: "Noto Sans JP";
@@ -129,7 +133,6 @@ body {
     background-color: #ffffff;
     color: #da6220;
     padding: 8px 15px;
-    width: 68px;
     border-radius: 5px;
     border: none;
     line-height: 1;
@@ -158,11 +161,15 @@ body {
     margin: 0 auto;
     max-width: 480px;
 }
+.form-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 20px;
+}
 
 .login-form {
     display: flex;
     flex-direction: column;
-    gap: 50px;
 }
 .login-button {
     background-color: #da6220;
@@ -396,90 +403,155 @@ body {
     cursor: pointer;
 }
 
-.symptom-legend {
+.section-title {
+    font-size: 14px;
+    font-weight: 600;
+    margin: 16px 0 10px;
+    display: flex;
+    justify-content: left;
+  }
+  
+  .muted {
+    color: #777;
+    font-size: 13px;
+  }
+
+  .streak-cards {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px 16px;
-    justify-content: center;
-    margin-bottom: 16px;
-}
+    gap: 8px;
+  }
   
-.legend-item {
-    display: flex;
+  .streak-card {
+    display: inline-flex;
     align-items: center;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid #ede8d1;
+    border-radius: 12px;
+    background: #fff;
+  }
+  
+  .streak-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #ede8d1;
+  }
+  
+  .streak-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #da6220;
+  }
+  
+  .streak-days {
     font-size: 12px;
-}
-  
-.legend-color {
-    width: 12px;
-    height: 12px;
-    margin-right: 6px;
-    border-radius: 2px;
-}
+    color: #666;
+  }
 
-.legend-color.headache { background: #f44336; }
-.legend-color.cough { background: #2196f3; }
-.legend-color.runny_nose { background: #03a9f4; }
-.legend-color.rash { background: #e91e63; }
-.legend-color.vomit { background: #ff9800; }
-.legend-color.stool { background: #8bc34a; }
-.legend-color.temperature { background: #9c27b0; }
-
-.weekly-matrix {
-    display: flex;
-    gap: 48px;
-}
+  .week-card {
+    border: 1px solid #ede8d1;
+    border-radius: 12px;
+    background: #fff;
+    padding: 10px 12px;
+    margin-top: 12px;
+  }
   
-.week-column {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
+  .week-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: #666;
+    margin-bottom: 8px;
+  }
   
-.day-row {
+  .day-item {
     display: flex;
-    align-items: center;
-    margin: 0;
-}
+    gap: 12px;
+    padding: 10px 0;
+    border-top: 1px solid #f2edd7;
+  }
   
-.weekday {
-    width: 32px;
+  .day-item:first-of-type { border-top: none; }
+  
+  .day-date {
+    width: 74px;
+    flex: 0 0 auto;
     text-align: center;
-    font-size: 12px;
-}
+    color: #666;
+  }
   
-.symptom-cells {
+  .day-wday { display: block; font-size: 12px; }
+  .day-md   { display: block; font-size: 13px; font-weight: 600; }
+  
+  .day-tags {
     display: flex;
-    gap: 0;
-}
-  
-.symptom-cell {
-    width: 12px;
-    height: 24px;
-    background: #eee;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    border-radius: 999px;
+    border: 1px solid #ede8d1;
+    background: #f8f5e6;
+    font-size: 13px;
+    color: #da6220;
+  }
+
+.streak-dot.headache,
+.tag.headache {
+  background: #c85a3a;
 }
 
-  /* active + 症状色 */
-.symptom-cell.active {
-    background: #4caf50;
+.streak-dot.cough,
+.tag.cough {
+  background: #b86a3c;
 }
 
-.symptom-cell.headache { background: #f44336; }
-.symptom-cell.cough { background: #2196f3; }
-.symptom-cell.runny_nose { background: #03a9f4; }
-.symptom-cell.rash { background: #e91e63; }
-.symptom-cell.vomit { background: #ff9800; }
-.symptom-cell.stool { background: #8bc34a; }
-.symptom-cell.temperature { background: #9c27b0; }
+.streak-dot.runny_nose,
+.tag.runny_nose {
+  background: #d9a441;
+}
+
+.streak-dot.rash,
+.tag.rash {
+  background: #c04f6f;
+}
+
+.streak-dot.vomit,
+.tag.vomit {
+  background: #b87333;
+}
+
+.streak-dot.stool,
+.tag.stool {
+  background: #8f7a4a;
+}
+
+.streak-dot.temperature,
+.tag.temperature {
+  background: #a75b8a;
+}
+
+.tag.headache,
+.tag.cough,
+.tag.runny_nose,
+.tag.rash,
+.tag.vomit,
+.tag.stool,
+.tag.temperature {
+  color: #ffffff;
+  border-color: transparent;
+}
+
 
 .symptom-trend {
     margin-top: 32px;
     padding: 16px;
-}
-  
-.symptom-trend h3 {
-    text-align: center;
-    margin-bottom: 12px;
 }
 
 .kid-index {

--- a/app/javascript/charts/symptom_trend_chart.js
+++ b/app/javascript/charts/symptom_trend_chart.js
@@ -1,6 +1,14 @@
 export function renderSymptomTrendChart(canvas, chartData) {
   if (!canvas) return;
 
+  const COLORS = {
+    mainText: "#da6220",
+    grid: "#ede8d1",
+    temperature: "#a75b8a",
+    vomit: "#b87333",
+    stool: "#8f7a4a"
+  };
+
   new Chart(canvas, {
     type: "line",
     data: {
@@ -11,25 +19,60 @@ export function renderSymptomTrendChart(canvas, chartData) {
           data: chartData.temperature,
           yAxisID: "y-temp",
           borderWidth: 2,
-          spanGaps: true
+          spanGaps: true,
+          borderColor: COLORS.temperature,
+          pointBackgroundColor: COLORS.temperature,
+          pointBorderColor: COLORS.temperature,
+          backgroundColor: "transparent",
+          tension: 0.3,
+          pointRadius: 3,
+          fill: true,
+          backgroundColor: "rgba(167, 91, 138, 0.12)"
         },
         {
-          label: "嘔吐回数",
+          label: "嘔吐",
           data: chartData.vomit,
           yAxisID: "y-count",
-          borderWidth: 2
+          borderWidth: 2,
+          borderColor: COLORS.vomit,
+          pointBackgroundColor: COLORS.vomit,
+          pointBorderColor: COLORS.vomit,
+          backgroundColor: "transparent",
+          tension: 0.3,
+          pointRadius: 3,
+          fill: true,
+          backgroundColor: "rgba(184, 115, 51, 0.15)"
         },
         {
-          label: "便回数",
+          label: "便",
           data: chartData.stool,
           yAxisID: "y-count",
-          borderWidth: 2
+          borderWidth: 2,
+          borderColor: COLORS.stool,
+          pointBackgroundColor: COLORS.stool,
+          pointBorderColor: COLORS.stool,
+          backgroundColor: "transparent",
+          tension: 0.3,
+          pointRadius: 3,
+          fill: true,
+          backgroundColor: "rgba(143, 122, 74, 0.15)"
         }
       ]
     },
     options: {
       responsive: true,
+      plugins: {
+        legend: {
+          labels: {
+            color: COLORS.mainText
+          }
+        }
+      },
       scales: {
+        x: {
+          ticks: { color: COLORS.mainText },
+          grid: { color: COLORS.grid }
+        },
         "y-temp": {
           type: "linear",
           position: "left",
@@ -37,11 +80,14 @@ export function renderSymptomTrendChart(canvas, chartData) {
           max: 41,
           ticks: {
             stepSize: 1,
+            color: COLORS.mainText,
             callback: (v) => v.toFixed(1)
           },
+          grid: { color: COLORS.grid },
           title: {
             display: true,
             text: "体温（℃）",
+            color: COLORS.mainText,
             rotation: -90,
             padding: {
               top: 10,
@@ -54,7 +100,8 @@ export function renderSymptomTrendChart(canvas, chartData) {
           position: "right",
           min: 0,
           ticks: {
-            stepSize: 1
+            stepSize: 1,
+            color: COLORS.mainText
           },
           grid: {
             drawOnChartArea: false
@@ -62,6 +109,7 @@ export function renderSymptomTrendChart(canvas, chartData) {
           title: {
             display: true,
             text: "回数",
+            color: COLORS.mainText,
             rotation: 90,
             padding: {
               top: 10,

--- a/app/views/reported_symptoms/summary.html.erb
+++ b/app/views/reported_symptoms/summary.html.erb
@@ -66,41 +66,63 @@
   <% if @tab == "all" %>
     <div class="symptom-legend">
       <% @symptom_slots.each do |key, label| %>
-        <div class="legend-item">
-          <span class="legend-color <%= key %>"></span>
-          <span class="legend-label"><%= label %></span>
-        </div>
       <% end %>
     </div>
 
-    <div class="weekly-matrix">
+    <section class="streak">
+      <h3 class="section-title">続いている症状（今日）</h3>
+
+      <% if @active_symptoms.present? %>
+        <div class="streak-cards">
+          <% @active_symptoms.each do |s| %>
+            <div class="streak-card">
+              <span class="streak-dot <%= s[:key] %>"></span>
+              <span class="streak-label"><%= s[:label] %></span>
+              <% if s[:days].present? %>
+                <span class="streak-days"><%= s[:days] %>日目</span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="muted">今日は記録された症状はありません</p>
+      <% end %>
+    </section>
+
+    <section class="daily-log">
+      <h3 class="section-title">これまでの経過</h3>
 
       <% [:last, :this].each do |week_key| %>
-        <div class="week-column">
-          <h3><%= week_key == :last ? "先週" : "今週" %></h3>
+        <div class="week-card">
+          <div class="week-title"><%= week_key == :this ? "今週" : "先週" %></div>
 
           <% @weeks[week_key].each do |date| %>
-            <div class="day-row">
-              <div class="weekday">
-                <%= date.strftime("%a") %>
+            <% items = @daily_symptoms[date] || [] %>
+
+            <div class="day-item">
+              <div class="day-date">
+                <span class="day-wday"><%= date.strftime("%a") %></span>
+                <span class="day-md"><%= date.strftime("%-m/%-d") %></span>
               </div>
 
-              <div class="symptom-cells">
-                <% @symptom_slots.each do |key, label| %>
-                  <div class="symptom-cell <%= "active #{key}" if @matrix[date][key] %>">
-                  </div>
+              <div class="day-tags">
+                <% if items.any? %>
+                  <% items.each do |t| %>
+                    <span class="tag <%= t[:key] %>"><%= t[:label] %></span>
+                  <% end %>
+               <% else %>
+                  <span class="muted">症状なし</span>
                 <% end %>
               </div>
             </div>
-
           <% end %>
-
         </div>
       <% end %>
-    </div>
+    </section>
+
 
     <div class="symptom-trend">
-      <h3>症状の推移</h3>
+    <h3 class="section-title">体温/嘔吐/便の推移</h3>
 
       <canvas id="symptomTrendChart"
         data-chart="<%= j @chart_data.to_json %>">


### PR DESCRIPTION
## 内容
- 縦方向の棒グラフ上だったサマリーをウィークリーカレンダー方式に変更（棒グラフが非常にわかりづらかったため）。
- 今日まで続いている症状をトップに表示。
- 症状別の色をサイトイメージと統一。
- 上記変更に伴い崩れた別ページのCSSを修正。