### PR TITLE
style:過去の体調不良一覧を箇条書きから改善

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -720,3 +720,76 @@ body {
     margin-top: 12px;
     text-align: center;
 }
+
+.record-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+  }
+  
+  .record-card {
+    background: #fff;
+    border: 1px solid #ede8d1;
+    border-radius: 14px;
+    padding: 14px 14px 12px;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.05);
+  }
+  
+  .record-card__header {
+    display: grid;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  
+  .record-period {
+    font-size: 12px;
+    color: #666;
+  }
+  
+  .record-period__sep {
+    margin: 0 6px;
+    color: #999;
+  }
+  
+  .record-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: #da6220;
+  }
+  
+  .record-symptoms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+  
+  .mini-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 10px;
+    border-radius: 999px;
+    background: #ede8d1;
+    color: #da6220;
+    font-size: 12px;
+    border: 1px solid rgba(218, 98, 32, 0.12);
+  }
+  
+  .record-symptoms__empty {
+    font-size: 12px;
+    color: #777;
+  }
+
+  .search-button {
+    display: inline-flex;
+  padding: 6px 18px;
+  background-color: #ede8d1;
+  color: #da6220;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  align-items: center;
+  margin-bottom: 50px;
+  }

--- a/app/controllers/disease_records_controller.rb
+++ b/app/controllers/disease_records_controller.rb
@@ -34,30 +34,34 @@ class DiseaseRecordsController < ApplicationController
 
   def index
     records = @kid.disease_records.where.not(end_at: nil)
-
+  
     # 病名検索
     if params[:disease_name].present?
       records = records.where("name LIKE ?", "%#{params[:disease_name]}%")
     end
-
+  
     # 期間検索
     if params[:from].present?
       records = records.where("start_at >= ?", params[:from])
     end
-
+  
     if params[:to].present?
       records = records.where("end_at <= ?", params[:to])
     end
-
+  
     # 症状検索
     if params[:symptom_name_id].present?
       records = records.joins(:reported_symptoms)
                        .where(reported_symptoms: { symptom_name_id: params[:symptom_name_id] })
                        .distinct
     end
-
-    @disease_records = records.order(end_at: :desc)
+  
+    @disease_records =
+      records
+        .includes(reported_symptoms: :symptom_name)  # ← 追加（症状表示のN+1回避）
+        .order(end_at: :desc)
   end
+  
 
   private
 

--- a/app/views/disease_records/index.html.erb
+++ b/app/views/disease_records/index.html.erb
@@ -1,30 +1,78 @@
-<h1>過去の体調不良</h1>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>medical record - 過去の体調不良一覧</title>
+</head>
+<body>
+  <main class="login-main">
 
-<ul>
+  <div class="summary-header">
+      <h2>過去の体調不良検索</h2>
+    </div>
+
+  <%= form_with url: kid_disease_records_path(@kid), method: :get, local: true do |f| %>
+    <div class="form-row"> 
+      <%= f.text_field :disease_name, placeholder: "病名", rows: 2, class: "form-control" %>
+    </div>
+  
+    <div class="form-row">
+    <%= f.select :symptom_name_id,
+    options_from_collection_for_select(SymptomName.all, :id, :name),
+    { include_blank: "症状を選択してください" },
+    { class: "form-control" } %>
+    </div>
+  
+    <div class="form-row form-row--date">
+    <%= f.date_field :from, class: "form-control" %>
+    <span class="date-separator">〜</span>
+    <%= f.date_field :to, class: "form-control" %>
+  </div>
+  
+  <div class="form-actions">
+    <%= f.submit "検索", class: "search-button"%>
+  </div>
+  <% end %>
+
+    <div class="summary-header">
+      <h2>過去の体調不良一覧</h2>
+    </div>
+
+    <ul class="record-list">
   <% @disease_records.each do |record| %>
-    <li>
-      <%= record.start_at.to_date %> 〜
-      <%= record.end_at.to_date %><br>
-      <%= record.name %>
+    <% symptom_names =
+      record.reported_symptoms
+            .map { |rs| rs.symptom_name&.name }
+            .compact
+            .uniq
+    %>
+    <% if record.reported_symptoms.any? { |rs| rs.body_temperature.present? } %>
+      <% symptom_names << "体温" unless symptom_names.include?("体温") %>
+    <% end %>
+
+    <li class="record-card">
+      <div class="record-card__header">
+        <div class="record-period">
+          <%= l record.start_at.to_date, format: :long %>
+          <span class="record-period__sep">〜</span>
+          <%= l record.end_at.to_date, format: :long %>
+        </div>
+
+        <div class="record-name"><%= record.name %></div>
+      </div>
+
+      <div class="record-symptoms">
+        <% if symptom_names.any? %>
+          <% symptom_names.each do |name| %>
+            <span class="mini-tag"><%= name %></span>
+          <% end %>
+        <% else %>
+          <span class="record-symptoms__empty">症状の記録なし</span>
+        <% end %>
+      </div>
     </li>
   <% end %>
 </ul>
-
-<%= form_with url: kid_disease_records_path(@kid), method: :get, local: true do |f| %>
-  <div>
-    病名
-    <%= f.text_field :disease_name %>
-  </div>
-
-  <div>
-    症状
-    <%= f.select :symptom_name_id,options_from_collection_for_select(SymptomName.all, :id, :name),include_blank: "選択してください" %>
-  </div>
-
-  <div>
-    期間
-    <%= f.date_field :from %> 〜 <%= f.date_field :to %>
-  </div>
-
-  <%= f.submit "検索" %>
-<% end %>
+</body>
+</html>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  date:
+    formats:
+      long: "%Y年%-m月%-d日"


### PR DESCRIPTION
## 内容
- 箇条書き形式だった一覧表を1レコードで1カードの表示形式に変更。
- 症状（重複なし）も掲載。
- 検索をページトップに変更（レコードが多くなってきた際すぐにアクセスできるようにするため）。